### PR TITLE
Update changelog-on-tag.yaml

### DIFF
--- a/.github/workflows/changelog-on-tag.yaml
+++ b/.github/workflows/changelog-on-tag.yaml
@@ -24,5 +24,5 @@ jobs:
         with:
           tag: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          # create_file: true 
-          # Removed 'create_file' as it is not a valid input for this action
+          create_file: true 
+          


### PR DESCRIPTION
"create_file: true" fehlte

## Summary by Sourcery

CI:
- Uncomment and activate the 'create_file' option in the changelog-on-tag GitHub workflow to ensure changelog file generation